### PR TITLE
Add issuer cmd import eth privKey

### DIFF
--- a/servers/issuer/commands/server.go
+++ b/servers/issuer/commands/server.go
@@ -42,9 +42,19 @@ var ServerCommands = []cli.Command{
 	// 	Action:  cmd.WithCfg(cmd.CmdInfo),
 	// },
 	{
-		Name:    "newethaccount",
-		Aliases: []string{},
-		Usage:   "create new Eth Account Address",
-		Action:  cmd.CmdNewEthAccount,
+		Name:  "eth",
+		Usage: "create and manage eth wallet",
+		Subcommands: []cli.Command{{
+			Name:    "new",
+			Aliases: []string{},
+			Usage:   "create new Eth Account Address",
+			Action:  cmd.CmdNewEthAccount,
+		},
+			{
+				Name:    "import",
+				Aliases: []string{},
+				Usage:   "import Eth Account Private Key",
+				Action:  cmd.CmdImportEthAccount,
+			}},
 	},
 }


### PR DESCRIPTION
Tested with a exported private key from Metamask.

Now we have a `eth` command with two subcommands:
```bash
./issuer --config config.toml eth new     #create new Eth Account Address
./issuer eth import [keyfile] #import Eth Account Private Key
```

resolves #22